### PR TITLE
Update spi_flash_memory to add NAND support and numbered payload.

### DIFF
--- a/spi_flash_memory.js
+++ b/spi_flash_memory.js
@@ -829,8 +829,7 @@ function build_commands_db_nand()
 
   transaction = [];
   transaction.push(new header_t(0x03,"RD","Read Cache x1",ch_miso,IO_MISO));
-  transaction.push(new parameter_t(0.375,IO_MOSI,"A","3 dummy bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_MOSI,"A","Column Address",flash_format_address));
   transaction.push(new parameter_t(1,IO_MISO,"Dummy","1 Dummy byte",flash_format_data));
   commands.push(transaction);
 
@@ -839,8 +838,7 @@ function build_commands_db_nand()
 
   transaction = [];
   transaction.push(new header_t(0x02,"PL","Program Load x1",IO_MOSI));
-  transaction.push(new parameter_t(0.375,IO_MOSI,"A","3 dummy bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_MOSI,"A","Column Address",flash_format_address));
   commands.push(transaction);
 
   transaction = [];
@@ -850,8 +848,7 @@ function build_commands_db_nand()
 
   transaction = [];
   transaction.push(new header_t(0x84,"PLR","Program Load Random",IO_MOSI));
-  transaction.push(new parameter_t(0.375,IO_MOSI,"A","3 dummy bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_MOSI,"A","Column Address",flash_format_address));
   commands.push(transaction);
 
   //-------------- Block Erase Operations
@@ -886,15 +883,13 @@ function build_commands_db_nand()
 
   transaction = [];
   transaction.push(new header_t(0x3B,"RCx2","Read Cache x2",IO_DUAL));
-  transaction.push(new parameter_t(0.375,IO_MOSI,"A","Dummy Bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_MOSI,"A","Column Address",flash_format_address));
   transaction.push(new parameter_t(1,IO_MOSI,"Dummy","1 Dummy byte",flash_format_data));
   commands.push(transaction);
 
   transaction = [];
   transaction.push(new header_t(0x6B,"RCx4","Read Cache x4",IO_QUAD));
-  transaction.push(new parameter_t(0.375,IO_MOSI,"A","3 dummy bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_MOSI,"A","Column Address",flash_format_address));
   transaction.push(new parameter_t(4,IO_MOSI,"Dummy","4 Dummy bytes",flash_format_data));
   commands.push(transaction);
 
@@ -906,33 +901,28 @@ function build_commands_db_nand()
 
   transaction = [];
   transaction.push(new header_t(0xEB,"RC4IO","Read Cache quad I/O",IO_QUAD));
-  transaction.push(new parameter_t(0.375,IO_QUAD,"A","3 dummy bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_QUAD,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_QUAD,"A","Column Address",flash_format_address));
   transaction.push(new parameter_t(2,IO_QUAD,"Dummy","2 Dummy bytes",flash_format_data));
   commands.push(transaction);
 
   transaction = [];
   transaction.push(new header_t(0xA2,"PLx2","Program Load x2",IO_DUAL));
-  transaction.push(new parameter_t(0.375,IO_MOSI,"A","3 dummy bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_MOSI,"A","Column Address",flash_format_address));
   commands.push(transaction);
 
   transaction = [];
   transaction.push(new header_t(0x44,"PLRx2","Program Load Random x2",IO_DUAL));
-  transaction.push(new parameter_t(0.375,IO_MOSI,"A","3 dummy bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_MOSI,"A","Column Address",flash_format_address));
   commands.push(transaction);
 
   transaction = [];
   transaction.push(new header_t(0x32,"PLx4","Program Load x4",IO_QUAD));
-  transaction.push(new parameter_t(0.375,IO_MOSI,"A","3 dummy bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_MOSI,"A","Column Address",flash_format_address));
   commands.push(transaction);
 
   transaction = [];
   transaction.push(new header_t(0x34,"PRDx4","Program Load Random x4",IO_QUAD));
-  transaction.push(new parameter_t(0.375,IO_MOSI,"A","3 dummy bits",flash_format_address));
-  transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
+  transaction.push(new parameter_t(2,IO_MOSI,"A","Column Address",flash_format_address));
   commands.push(transaction);
 
 }

--- a/spi_flash_memory.js
+++ b/spi_flash_memory.js
@@ -35,7 +35,7 @@ function on_draw_gui_decoder()
   // Type of flash, determines what commands db is used
   ScanaStudio.gui_add_combo_box("flash_type","Flash Type:")
   ScanaStudio.gui_add_item_to_combo_box("NOR",true);      // Index 0 = TYPE_NOR
-  ScanaStudio.gui_add_item_to_combo_box("NAND (Micron MT29FxG01)",false);
+  ScanaStudio.gui_add_item_to_combo_box("NAND (Micron MT29F 60 series)",false);
 
 
   if (ScanaStudio.get_device_channels_count() > 4)
@@ -786,7 +786,8 @@ function build_commands_db_nand()
 {
   // Micron MT29F2G01ABBGDxx, MT29F4G01ABBFDxx, MT29F8G01ADBFD12
   // Commands in datasheet order, apart from dual/quad IO
-  // https://www.micron.com/products/nand-flash/serial-nand/part-catalog/mt29f4g01abbfdwb-it (requires login)
+  // Micron refer to series as "MT29F, SLC, 60 series" in low level drivers ,see
+  // https://www.micron.com/support/software-and-drivers (login to download)
   // Note: MT29F2G01ABBGDxx has no PROTECT command or x2 Read/Write commands
   var transaction = [];
 

--- a/spi_flash_memory.js
+++ b/spi_flash_memory.js
@@ -316,7 +316,11 @@ function on_build_demo_signals()
   var silence_period = (samples_to_build / (125*ScanaStudio.builder_get_sample_rate()));
   var spi_builder = ScanaStudio.load_builder_object("spi.js");
   read_gui_values();
-  build_commands_db();
+  if (flash_type == TYPE_NOR) {
+      build_commands_db_nor();
+  } else {
+      build_commands_db_nand();
+  }
 
   spi_builder.config(
     ScanaStudio.gui_get_value("ch_mosi"),

--- a/spi_flash_memory.js
+++ b/spi_flash_memory.js
@@ -845,7 +845,7 @@ function build_commands_db_nand()
   commands.push(transaction);
 
   transaction = [];
-  transaction.push(new header_t(0x84,"PRD","Random Data Program x1",IO_MOSI));
+  transaction.push(new header_t(0x84,"PLR","Program Load Random",IO_MOSI));
   transaction.push(new parameter_t(0.375,IO_MOSI,"A","3 dummy bits",flash_format_address));
   transaction.push(new parameter_t(1.625,IO_MOSI,"A","Column Address",flash_format_address));
   commands.push(transaction);


### PR DESCRIPTION
Support for Micron MT29F 60 series NAND SPI flash.
I have tested most commands, apart from dual/quad.
Also added an option to enumarate each data byte, useful with long payloads.