### PR TITLE
Update i2c.js

### DIFF
--- a/i2c.js
+++ b/i2c.js
@@ -741,7 +741,7 @@ function on_build_trigger()
         trig_build_start();
         for(var i=0; i<7; i++)
         {
-            trig_build_bit(trig_addr>>(6-i));
+            trig_build_bit(trig_addr>>(6-i) & 0x01);
         }
 
         switch(trig_access_type)


### PR DESCRIPTION
Add bit mask to I2C address trigger generation on line 744. Prevents address bits after most significant '1' being treated as don't care. Withous this a trigger set match on say, 0x71 would trigger on any address with the MSB set at '1'.